### PR TITLE
feat: Add debounce mechanism for weather API calls (#33)

### DIFF
--- a/script.js
+++ b/script.js
@@ -16,6 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Block C: Service Configuration ---
    
     const weatherApiKey = 'YOUR_API_KEY_HERE';
+    let debounceTimer = null;
 
     // --- Block D: Module 1 Functions ---
     function renderTasks() {
@@ -54,10 +55,14 @@ document.addEventListener('DOMContentLoaded', () => {
   //---Can write the the required functions here
 
 
-
- 
-
-  
+    function debounceWeatherSearch(city) {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => {
+            if (city && city.trim().length > 0) {
+                fetchWeather(city.trim());
+            }
+        }, 500);
+    }
 
     // --- Block E: Module 2 Functions sample data ---
     async function fetchWeather(city) {
@@ -91,6 +96,11 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Block F: Event Registry ---
     addTaskBtn.addEventListener('click', addTask);
     clearAllBtn.addEventListener('click', clearAllTasks);
+
+    cityInput.addEventListener('input', (e) => {
+        const city = e.target.value.trim();
+        debounceWeatherSearch(city);
+    });
 
     searchWeatherBtn.addEventListener('click', () => {
         const city = cityInput.value.trim();


### PR DESCRIPTION
## Debounce Weather API Calls 
Implements a debounce mechanism to prevent excessive weather API requests when users type quickly in the city search input.

### Changes Made
- **Added debounce timer variable** to track timeout state
- **Implemented debounce function** with 500ms delay
- **Added input event listener** for real-time search with debouncing
- **Maintained existing functionality** - button click still works immediately

### How It Works
- User types in city input → triggers debounced search
- Each keystroke resets the 500ms timer
- API call only occurs after user stops typing for 500ms
- Button click bypasses debounce for immediate search



Closes #33