### PR TITLE
adding-task-by-EnterKey

### DIFF
--- a/script.js
+++ b/script.js
@@ -216,6 +216,13 @@ document.addEventListener("DOMContentLoaded", () => {
         });
     });
 
+    // Adding Task With Enter
+        taskInput.addEventListener('keypress',(e)=>{
+            if (e.key=="Enter"){
+                addTask();   
+            }
+        })
+
     // --- Block H: Application Entry Point ---
     function init() {
         renderTasks();


### PR DESCRIPTION
Hello @abhishek972986  Sir,
I have successfully implemented the event registry for TasksInput with Enter key.
Now user can add tasks without the need of using add task button.
Solved Issue #12

Sir please review the PR and please merge it.
Closes #12 


<img width="1717" height="950" alt="image" src="https://github.com/user-attachments/assets/ff5e644b-4aba-415f-a03f-560905a54708" />
